### PR TITLE
Refactor algorithms to use graph models

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains an implementation of the Ford-Fulkerson Algorithm for n
   - `algorithms.py`: Augmenting-path strategies (SAP, DFS-like, Random, MaxCap).
   - `graph_generation.py`: Random graph generation helpers and optional visualization utilities.
   - `io.py`: CSV helpers for persisting and loading graph data.
+  - `models.py`: Dataclasses representing immutable graphs and mutable residual networks.
 - `main.py`: Command line entry point that wires the package modules together.
 - `README.md`: Project documentation.
 - `requirements.txt`: List of required Python libraries.
@@ -47,22 +48,24 @@ The script checks for pre-generated simulation data (stored as CSV files) and, i
 ## Functions Overview
 #### Augmenting Path Strategies (`ford_fulkerson/algorithms.py`)
 
-    DFS-like: ford_fulkerson_DFS_like(capacities, source, sink, adjlist)
-    Random: ford_fulkerson_random(capacities, source, sink, adjlist)
-    MaxCap: ford_fulkerson_max_capacity(capacities, source, sink, adjList)
-    SAP: ford_fulkerson(capacities, source, sink)
+All strategies now operate on a `ResidualNetwork` created from a `GraphInstance`.
+
+    DFS-like: ford_fulkerson_DFS_like(residual_network)
+    Random: ford_fulkerson_random(residual_network)
+    MaxCap: ford_fulkerson_max_capacity(residual_network)
+    SAP: ford_fulkerson(residual_network)
 
 #### Graph Generation (`ford_fulkerson/graph_generation.py`)
 
-    GenerateSinkSourceGraph(n, r, upperCap): Generates a random source-sink graph.
+    GenerateSinkSourceGraph(n, r, upperCap): Generates a random source-sink graph as a GraphInstance.
     breadth_first_search(V, E, capacities, adjlist, source): Helper used to determine sink candidates.
-    get_sink(distance, parent): Returns the sink at the end of the longest acyclic path from the source.
+    get_sink(distance, parent, source): Returns the sink at the end of the longest acyclic path from the source.
 
 #### Visualization (Optional)
 
-    visualize_graph(V, E, capacities, source, sink): Visualizes the generated graph (for debugging and presentation purposes).
+    visualize_graph(vertices, edges, capacities, source, sink): Visualizes the generated graph (for debugging and presentation purposes).
 
 #### Data Persistence (`ford_fulkerson/io.py`)
 
-    save_graph_data(...): Persist generated graph data to CSV files.
-    read_data(...): Read graph data from the CSV files created by `save_graph_data`.
+    save_graph_data(graph, graph_no): Persist generated graph data to CSV files.
+    read_data(...): Read graph data from the CSV files created by `save_graph_data` and return a GraphInstance.

--- a/ford_fulkerson/__init__.py
+++ b/ford_fulkerson/__init__.py
@@ -7,14 +7,11 @@ from .algorithms import (
     ford_fulkerson_DFS_like,
     ford_fulkerson_max_capacity,
     ford_fulkerson_random,
+    ford_fulkerson_strategies,
 )
-from .graph_generation import (
-    GenerateSinkSourceGraph,
-    breadth_first_search,
-    get_sink,
-    visualize_graph,
-)
+from .graph_generation import GenerateSinkSourceGraph, breadth_first_search, get_sink, visualize_graph
 from .io import read_data, save_graph_data
+from .models import Edge, GraphInstance, ResidualNetwork, Vertex
 
 __all__ = [
     "BFS_FF_SAP",
@@ -25,8 +22,13 @@ __all__ = [
     "ford_fulkerson_DFS_like",
     "ford_fulkerson_max_capacity",
     "ford_fulkerson_random",
+    "ford_fulkerson_strategies",
     "get_sink",
     "read_data",
     "save_graph_data",
     "visualize_graph",
+    "Edge",
+    "GraphInstance",
+    "ResidualNetwork",
+    "Vertex",
 ]

--- a/ford_fulkerson/io.py
+++ b/ford_fulkerson/io.py
@@ -1,22 +1,26 @@
 """Helpers for persisting and loading graph data to CSV files."""
 
+from __future__ import annotations
+
 import csv
+import math
+from typing import Dict, List, Tuple
+
+from .models import GraphInstance
+
+Vertex = Tuple[float, float]
+Edge = Tuple[Vertex, Vertex]
 
 
-def save_graph_data(
-    V,
-    E,
-    capacities,
-    adjlist,
-    source,
-    sink,
-    n,
-    r,
-    upperCap,
-    max_distance,
-    total_edges_of_Graph,
-    graph_no,
-):
+def save_graph_data(graph: GraphInstance, graph_no: int) -> None:
+    """Persist ``graph`` and its metadata to CSV files for later reuse."""
+
+    meta_distance = graph.max_distance
+    if meta_distance is None or math.isinf(meta_distance):
+        meta_distance_value = "Inf"
+    else:
+        meta_distance_value = meta_distance
+
     with open(f"sim_val_{graph_no}_meta_info.csv", "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(
@@ -34,15 +38,15 @@ def save_graph_data(
         )
         writer.writerow(
             [
-                source[0],
-                source[1],
-                sink[0],
-                sink[1],
-                n,
-                r,
-                upperCap,
-                max_distance,
-                total_edges_of_Graph,
+                graph.source[0],
+                graph.source[1],
+                graph.sink[0],
+                graph.sink[1],
+                graph.n,
+                graph.r,
+                graph.upper_cap,
+                meta_distance_value,
+                graph.total_edges,
             ]
         )
         print("meta info saved")
@@ -50,68 +54,79 @@ def save_graph_data(
     with open(f"sim_val_{graph_no}_vertices.csv", "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(["x-coordinate", "y-coordinate"])
-        for v in V:
-            writer.writerow(v)
+        for vertex in graph.vertices:
+            writer.writerow(vertex)
 
     with open(f"sim_val_{graph_no}_edges.csv", "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(["v1_x", "v1_y", "v2_x", "v2_y"])
-        for edge in E:
+        for edge in graph.edges:
             writer.writerow([edge[0][0], edge[0][1], edge[1][0], edge[1][1]])
 
     with open(f"sim_val_{graph_no}_capacities.csv", "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(["v1_x", "v1_y", "v2_x", "v2_y", "capacity"])
-        for edge, capacity in capacities.items():
+        for edge, capacity in graph.capacities.items():
             writer.writerow([edge[0][0], edge[0][1], edge[1][0], edge[1][1], capacity])
 
     with open(f"sim_val_{graph_no}_adjlist.csv", "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(["vertex_x", "vertex_y", "pairs of vertices coordinates"])
-        for vertex, neighbors in adjlist.items():
-            writer.writerow([vertex[0], vertex[1], *[neighbor for n in neighbors for neighbor in n]])
+        for vertex, neighbors in graph.adjacency_list.items():
+            flattened: List[float] = []
+            for neighbour in neighbors:
+                flattened.extend([neighbour[0], neighbour[1]])
+            writer.writerow([vertex[0], vertex[1], *flattened])
     print("Info saved")
 
 
-def read_data(file_path1, file_path2, file_path3, file_path4, file_path5):
+def read_data(
+    file_path1: str,
+    file_path2: str,
+    file_path3: str,
+    file_path4: str,
+    file_path5: str,
+) -> GraphInstance:
+    """Reconstruct a :class:`GraphInstance` from CSV files produced by :func:`save_graph_data`."""
+
     with open(file_path1, "r") as csvfile:
         reader = csv.reader(csvfile)
         next(reader, None)
-        for row in reader:
-            source = (float(row[0]), float(row[1]))
-            sink = (float(row[2])), float(row[3])
-            n = float(row[4])
-            r = float(row[5])
-            upperCap = float(row[6])
-            maxdistance = row[7]
-            if maxdistance == "Inf":
-                maxdist = 18
-            else:
-                try:
-                    maxdist = float(maxdistance)
-                except ValueError:
-                    maxdist = 18
-            total_edges = float(row[8])
+        row = next(reader)
+        source: Vertex = (float(row[0]), float(row[1]))
+        sink: Vertex = (float(row[2]), float(row[3]))
+        n = int(float(row[4]))
+        r = float(row[5])
+        upperCap = float(row[6])
+        maxdistance_raw = row[7]
+        try:
+            maxdist = float("inf") if maxdistance_raw == "Inf" else float(maxdistance_raw)
+        except ValueError:
+            maxdist = 18.0
+        try:
+            total_edges = int(float(row[8]))
+        except ValueError:
+            total_edges = 0
 
-    V = []
+    vertices: List[Vertex] = []
     with open(file_path2, "r") as csvfile:
         reader = csv.reader(csvfile)
         next(reader, None)
 
         for row in reader:
             x, y = map(float, row)
-            V.append((x, y))
+            vertices.append((x, y))
 
-    E = set()
+    edges: List[Edge] = []
     with open(file_path3, "r") as csvfile:
         reader = csv.reader(csvfile)
         next(reader, None)
         for row in reader:
             u = (float(row[0]), float(row[1]))
             v = (float(row[2]), float(row[3]))
-            E.add((u, v))
+            edges.append((u, v))
 
-    capacities = {}
+    capacities: Dict[Edge, int] = {}
     with open(file_path4, "r") as csvfile:
         reader = csv.reader(csvfile)
         next(reader, None)
@@ -122,14 +137,28 @@ def read_data(file_path1, file_path2, file_path3, file_path4, file_path5):
             capacity = int(row[4])
             capacities[(u, v)] = capacity
 
-    adjlist = {}
+    adjacency_list: Dict[Vertex, List[Vertex]] = {}
     with open(file_path5, "r") as csvfile:
         reader = csv.reader(csvfile)
         next(reader, None)
         for row in reader:
             vertex = (float(row[0]), float(row[1]))
-            adjacent_vertices = [(float(row[i]), float(row[i + 1])) for i in range(2, len(row), 2)]
-            adjlist[vertex] = adjacent_vertices
+            adjacent_vertices = [
+                (float(row[i]), float(row[i + 1])) for i in range(2, len(row), 2)
+            ]
+            adjacency_list[vertex] = adjacent_vertices
 
-    return source, sink, n, r, upperCap, V, E, capacities, adjlist, maxdist, total_edges
+    return GraphInstance(
+        vertices=vertices,
+        edges=edges,
+        capacities=capacities,
+        adjacency_list=adjacency_list,
+        source=source,
+        sink=sink,
+        n=n,
+        r=r,
+        upper_cap=upperCap,
+        max_distance=maxdist,
+        total_edges=total_edges or len(edges),
+    )
 

--- a/ford_fulkerson/models.py
+++ b/ford_fulkerson/models.py
@@ -1,0 +1,118 @@
+"""Core data structures representing graphs and residual networks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Mapping, MutableMapping, Sequence, Tuple
+
+Vertex = Tuple[float, float]
+Edge = Tuple[Vertex, Vertex]
+
+
+@dataclass(frozen=True)
+class GraphInstance:
+    """Immutable snapshot of a generated graph and its metadata."""
+
+    vertices: Sequence[Vertex]
+    edges: Iterable[Edge]
+    capacities: Mapping[Edge, int]
+    adjacency_list: Mapping[Vertex, Sequence[Vertex]]
+    source: Vertex
+    sink: Vertex
+    n: int
+    r: float
+    upper_cap: float
+    max_distance: float | None = None
+    total_edges: int | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "vertices", tuple(self.vertices))
+        object.__setattr__(self, "edges", frozenset(self.edges))
+        object.__setattr__(
+            self,
+            "adjacency_list",
+            {vertex: tuple(neighbors) for vertex, neighbors in self.adjacency_list.items()},
+        )
+        object.__setattr__(self, "capacities", dict(self.capacities))
+        if self.total_edges is None:
+            object.__setattr__(self, "total_edges", len(self.edges))
+
+    def create_residual_network(self) -> "ResidualNetwork":
+        """Construct a fresh residual network derived from this graph."""
+
+        return ResidualNetwork(graph=self)
+
+
+@dataclass
+class ResidualNetwork:
+    """Mutable view over residual capacities derived from a graph instance."""
+
+    graph: GraphInstance
+    capacities: MutableMapping[Edge, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.capacities:
+            self.capacities = dict(self.graph.capacities)
+        else:
+            self.capacities = dict(self.capacities)
+
+    @property
+    def source(self) -> Vertex:
+        return self.graph.source
+
+    @property
+    def sink(self) -> Vertex:
+        return self.graph.sink
+
+    @property
+    def vertices(self) -> Tuple[Vertex, ...]:
+        return self.graph.vertices
+
+    def get_capacity(self, u: Vertex, v: Vertex) -> float:
+        """Return the current residual capacity of edge (u, v)."""
+
+        return self.capacities.get((u, v), 0.0)
+
+    def set_capacity(self, u: Vertex, v: Vertex, value: float) -> None:
+        """Set the residual capacity on edge (u, v)."""
+
+        if value <= 0:
+            self.capacities.pop((u, v), None)
+        else:
+            self.capacities[(u, v)] = value
+
+    def update(self, u: Vertex, v: Vertex, delta: float) -> float:
+        """Adjust the capacity of edge (u, v) by ``delta`` and return the new value."""
+
+        new_value = self.get_capacity(u, v) + delta
+        self.set_capacity(u, v, new_value)
+        return self.get_capacity(u, v)
+
+    def augment(self, path: Sequence[Edge], bottleneck: float) -> None:
+        """Apply an augmentation along ``path`` with the given ``bottleneck`` value."""
+
+        for u, v in path:
+            self.update(u, v, -bottleneck)
+            self.update(v, u, bottleneck)
+
+    def neighbors(self, u: Vertex) -> List[Vertex]:
+        """Return all vertices reachable from ``u`` via positive residual capacity."""
+
+        return [v for (src, v), cap in self.capacities.items() if src == u and cap > 0]
+
+    def max_capacity(self) -> float:
+        """Return the maximum residual capacity currently available."""
+
+        positive_capacities = [cap for cap in self.capacities.values() if cap > 0]
+        return max(positive_capacities, default=0.0)
+
+    def clone(self) -> "ResidualNetwork":
+        """Return a deep copy of this residual network."""
+
+        return ResidualNetwork(graph=self.graph, capacities=self.capacities)
+
+    def snapshot(self) -> "ResidualNetwork":
+        """Alias for :meth:`clone` to comply with various naming preferences."""
+
+        return self.clone()
+

--- a/main.py
+++ b/main.py
@@ -2,18 +2,16 @@
 
 import os
 
+from math import isinf
+from typing import Optional
+
 from ford_fulkerson.algorithms import (
     ford_fulkerson,
     ford_fulkerson_DFS_like,
     ford_fulkerson_max_capacity,
     ford_fulkerson_random,
 )
-from ford_fulkerson.graph_generation import (
-    GenerateSinkSourceGraph,
-    breadth_first_search,
-    get_sink,
-    visualize_graph,
-)
+from ford_fulkerson.graph_generation import GenerateSinkSourceGraph, visualize_graph
 from ford_fulkerson.io import read_data, save_graph_data
 
 
@@ -33,27 +31,10 @@ def generate_graphs():
     graph_no = 0
     for n, r, upperCap in SIMULATION_VALUES:
         graph_no += 1
-        V, E, capacities, source, adjlist = GenerateSinkSourceGraph(n, r, upperCap)
+        graph = GenerateSinkSourceGraph(n, r, upperCap)
 
-        distance, parent = breadth_first_search(V, E, capacities, adjlist, source)
-        sink, max_distance = get_sink(distance, parent)
-        visualize_graph(V, E, capacities, source, sink)
-        max_distance = distance
-        total_edges_of_Graph = len(E)
-        save_graph_data(
-            V,
-            E,
-            capacities,
-            adjlist,
-            source,
-            sink,
-            n,
-            r,
-            upperCap,
-            max_distance,
-            total_edges_of_Graph,
-            graph_no,
-        )
+        visualize_graph(graph.vertices, graph.edges, graph.capacities, graph.source, graph.sink)
+        save_graph_data(graph, graph_no)
 
 
 def run_algorithms(graph_no):
@@ -63,60 +44,54 @@ def run_algorithms(graph_no):
     capacities_path = f"sim_val_{graph_no}_capacities.csv"
     adjlist_path = f"sim_val_{graph_no}_adjlist.csv"
 
-    source, sink, n, r, upperCap, V, E, capacities, adjlist, maxdist, total_edges_of_Graph = read_data(
-        meta_info_path, vertices_path, edges_path, capacities_path, adjlist_path
-    )
+    graph = read_data(meta_info_path, vertices_path, edges_path, capacities_path, adjlist_path)
 
-    print(f"\nThe source is {source} and the sink is {sink}")
+    print(f"\nThe source is {graph.source} and the sink is {graph.sink}")
 
-    max_flow_SAP, TAP_SAP, ml_Sap = ford_fulkerson(capacities, source, sink)
-    MPL = ml_Sap / maxdist
+    residual = graph.create_residual_network()
+
+    max_flow_SAP, TAP_SAP, ml_Sap = ford_fulkerson(residual.clone())
+    MPL = _compute_mpl(graph.max_distance, ml_Sap)
     print(f"The maximum possible flow for SAP (graph {graph_no}) is {max_flow_SAP}")
     print(f"total augmenting paths for SAP for graph {graph_no} is {TAP_SAP}")
     print(f"Mean Length for SAP for graph {graph_no} is {ml_Sap}")
     print(f"MPL for graph {graph_no} is {MPL}")
-    print(f"Total edges of graph {graph_no} is {total_edges_of_Graph}")
+    print(f"Total edges of graph {graph_no} is {graph.total_edges}")
 
-    source, sink, n, r, upperCap, V, E, capacities, adjlist, maxdist, total_edges_of_Graph = read_data(
-        meta_info_path, vertices_path, edges_path, capacities_path, adjlist_path
-    )
-
-    print(f"\nThe source is {source} and the sink is {sink}")
-
-    max_flow_DFS_like, TAP_DFS_like, ml_DFS_like = ford_fulkerson_DFS_like(capacities, source, sink, adjlist)
-    MPL = ml_DFS_like / maxdist
+    max_flow_DFS_like, TAP_DFS_like, ml_DFS_like = ford_fulkerson_DFS_like(residual.clone())
+    MPL = _compute_mpl(graph.max_distance, ml_DFS_like)
+    print(f"\nThe source is {graph.source} and the sink is {graph.sink}")
     print(f"The maximum possible flow for DFS (graph {graph_no}) is {max_flow_DFS_like}")
     print(f"total augmenting paths for DFS-like for graph {graph_no} is {TAP_DFS_like}")
     print(f"Mean Length for DFS-like graph {graph_no} is {ml_DFS_like}")
     print(f"MPL for graph {graph_no} is {MPL}")
-    print(f"Total edges of graph {graph_no} is {total_edges_of_Graph}")
+    print(f"Total edges of graph {graph_no} is {graph.total_edges}")
 
-    source, sink, n, r, upperCap, V, E, capacities, adjlist, maxdist, total_edges_of_Graph = read_data(
-        meta_info_path, vertices_path, edges_path, capacities_path, adjlist_path
-    )
-
-    print(f"\nThe source is {source} and the sink is {sink}")
-    max_flow_maxcap, TAP_maxCap, ml_maxCap = ford_fulkerson_max_capacity(capacities, source, sink, adjlist)
-    MPL = ml_maxCap / maxdist
+    max_flow_maxcap, TAP_maxCap, ml_maxCap = ford_fulkerson_max_capacity(residual.clone())
+    MPL = _compute_mpl(graph.max_distance, ml_maxCap)
+    print(f"\nThe source is {graph.source} and the sink is {graph.sink}")
     print(f"The maximum possible flow for maxCap (graph {graph_no}) is {max_flow_maxcap}")
     print(f"total augmenting paths for maxCap for graph {graph_no} is {TAP_maxCap}")
     print(f"Mean Length for maxCap graph {graph_no} is {ml_maxCap}")
     print(f"MPL for graph {graph_no} is {MPL}")
-    print(f"Total edges of graph {graph_no} is {total_edges_of_Graph}")
+    print(f"Total edges of graph {graph_no} is {graph.total_edges}")
 
-    source, sink, n, r, upperCap, V, E, capacities, adjlist, maxdist, total_edges_of_Graph = read_data(
-        meta_info_path, vertices_path, edges_path, capacities_path, adjlist_path
-    )
-
-    print(f"\nThe source is {source} and the sink is {sink}")
-
-    max_flow_random, TAP_random, ml_random = ford_fulkerson_random(capacities, source, sink, adjlist)
-    MPL = ml_random / maxdist
+    max_flow_random, TAP_random, ml_random = ford_fulkerson_random(residual.clone())
+    MPL = _compute_mpl(graph.max_distance, ml_random)
+    print(f"\nThe source is {graph.source} and the sink is {graph.sink}")
     print(f"The maximum possible flow for random (graph {graph_no}) is {max_flow_random}")
     print(f"total augmenting paths for random for graph {graph_no} is {TAP_random}")
     print(f"Mean Length for random graph {graph_no} is {ml_random}")
     print(f"MPL for graph {graph_no} is {MPL}")
-    print(f"Total edges of graph {graph_no} is {total_edges_of_Graph}")
+    print(f"Total edges of graph {graph_no} is {graph.total_edges}")
+
+
+def _compute_mpl(max_distance: Optional[float], mean_length: float) -> float:
+    if max_distance in (None, 0):
+        return 0
+    if isinf(float(max_distance)):
+        return 0
+    return mean_length / float(max_distance)
 
 
 def main():


### PR DESCRIPTION
## Summary
- add `GraphInstance` and `ResidualNetwork` dataclasses with helper APIs for cloning and residual updates
- update graph generation, CSV persistence, and Ford–Fulkerson algorithms to operate on the new models
- refresh the main script and README to document the revised interfaces

## Testing
- python -m compileall ford_fulkerson main.py

------
