### PR TITLE
Add runner module for strategy execution

### DIFF
--- a/ford_fulkerson/__init__.py
+++ b/ford_fulkerson/__init__.py
@@ -12,6 +12,7 @@ from .algorithms import (
 from .graph_generation import GenerateSinkSourceGraph, breadth_first_search, get_sink, visualize_graph
 from .io import read_data, save_graph_data
 from .models import Edge, GraphInstance, ResidualNetwork, Vertex
+from .runner import GraphRunResult, StrategyMetrics, run_strategies_for_graph
 
 __all__ = [
     "BFS_FF_SAP",
@@ -27,6 +28,9 @@ __all__ = [
     "read_data",
     "save_graph_data",
     "visualize_graph",
+    "GraphRunResult",
+    "StrategyMetrics",
+    "run_strategies_for_graph",
     "Edge",
     "GraphInstance",
     "ResidualNetwork",

--- a/ford_fulkerson/runner.py
+++ b/ford_fulkerson/runner.py
@@ -1,0 +1,112 @@
+"""Utilities for executing Ford-Fulkerson strategies over stored graphs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isinf
+from typing import Callable, Dict, Mapping, MutableMapping, Tuple
+
+from .algorithms import (
+    ford_fulkerson,
+    ford_fulkerson_DFS_like,
+    ford_fulkerson_max_capacity,
+    ford_fulkerson_random,
+)
+from .io import read_data
+from .models import GraphInstance, ResidualNetwork
+
+StrategyCallable = Callable[[ResidualNetwork], Tuple[float, int, float]]
+
+
+@dataclass(frozen=True)
+class StrategyMetrics:
+    """Summary metrics reported by a Ford-Fulkerson strategy."""
+
+    max_flow: float
+    augmenting_paths: int
+    mean_length: float
+    mpl: float
+
+
+@dataclass(frozen=True)
+class GraphRunResult:
+    """Container for the metrics gathered from all strategies for a graph."""
+
+    graph_no: int
+    graph: GraphInstance
+    strategies: Dict[str, StrategyMetrics]
+
+
+DEFAULT_STRATEGIES: MutableMapping[str, StrategyCallable] = {
+    "sap": ford_fulkerson,
+    "dfs_like": ford_fulkerson_DFS_like,
+    "max_capacity": ford_fulkerson_max_capacity,
+    "random": ford_fulkerson_random,
+}
+
+
+def _graph_file_paths(graph_no: int) -> Tuple[str, str, str, str, str]:
+    prefix = f"sim_val_{graph_no}"
+    return (
+        f"{prefix}_meta_info.csv",
+        f"{prefix}_vertices.csv",
+        f"{prefix}_edges.csv",
+        f"{prefix}_capacities.csv",
+        f"{prefix}_adjlist.csv",
+    )
+
+
+def _compute_mpl(max_distance: float | None, mean_length: float) -> float:
+    if not max_distance or isinf(float(max_distance)):
+        return 0.0
+    return mean_length / float(max_distance)
+
+
+def run_strategies_for_graph(
+    graph_no: int,
+    strategies: Mapping[str, StrategyCallable] | None = None,
+) -> GraphRunResult:
+    """Load ``graph_no`` once and execute each strategy on fresh clones."""
+
+    strategy_map: Dict[str, StrategyCallable]
+    if strategies is None:
+        strategy_map = dict(DEFAULT_STRATEGIES)
+    else:
+        strategy_map = dict(strategies)
+
+    graph = read_data(*_graph_file_paths(graph_no))
+    base_network = graph.create_residual_network()
+
+    print(f"\nGraph {graph_no}: source {graph.source}, sink {graph.sink}")
+    if graph.total_edges is not None:
+        print(f"Total edges: {graph.total_edges}")
+
+    results: Dict[str, StrategyMetrics] = {}
+
+    for strategy_name, strategy in strategy_map.items():
+        network = base_network.clone()
+        max_flow, augmenting_paths, mean_length = strategy(network)
+        mpl = _compute_mpl(graph.max_distance, mean_length)
+
+        metrics = StrategyMetrics(
+            max_flow=max_flow,
+            augmenting_paths=augmenting_paths,
+            mean_length=mean_length,
+            mpl=mpl,
+        )
+
+        results[strategy_name] = metrics
+
+        print(
+            "[{name}] max_flow={max_flow}, augmenting_paths={paths}, "
+            "mean_length={mean_length}, mpl={mpl}".format(
+                name=strategy_name,
+                max_flow=max_flow,
+                paths=augmenting_paths,
+                mean_length=mean_length,
+                mpl=mpl,
+            )
+        )
+
+    return GraphRunResult(graph_no=graph_no, graph=graph, strategies=results)
+

--- a/main.py
+++ b/main.py
@@ -2,17 +2,9 @@
 
 import os
 
-from math import isinf
-from typing import Optional
-
-from ford_fulkerson.algorithms import (
-    ford_fulkerson,
-    ford_fulkerson_DFS_like,
-    ford_fulkerson_max_capacity,
-    ford_fulkerson_random,
-)
 from ford_fulkerson.graph_generation import GenerateSinkSourceGraph, visualize_graph
-from ford_fulkerson.io import read_data, save_graph_data
+from ford_fulkerson.io import save_graph_data
+from ford_fulkerson.runner import run_strategies_for_graph
 
 
 SIMULATION_VALUES = [
@@ -33,84 +25,32 @@ def generate_graphs():
         graph_no += 1
         graph = GenerateSinkSourceGraph(n, r, upperCap)
 
-        visualize_graph(graph.vertices, graph.edges, graph.capacities, graph.source, graph.sink)
+        visualize_graph(
+            graph.vertices,
+            graph.edges,
+            graph.capacities,
+            graph.source,
+            graph.sink,
+        )
         save_graph_data(graph, graph_no)
 
 
-def run_algorithms(graph_no):
-    meta_info_path = f"sim_val_{graph_no}_meta_info.csv"
-    vertices_path = f"sim_val_{graph_no}_vertices.csv"
-    edges_path = f"sim_val_{graph_no}_edges.csv"
-    capacities_path = f"sim_val_{graph_no}_capacities.csv"
-    adjlist_path = f"sim_val_{graph_no}_adjlist.csv"
-
-    graph = read_data(meta_info_path, vertices_path, edges_path, capacities_path, adjlist_path)
-
-    print(f"\nThe source is {graph.source} and the sink is {graph.sink}")
-
-    residual = graph.create_residual_network()
-
-    max_flow_SAP, TAP_SAP, ml_Sap = ford_fulkerson(residual.clone())
-    MPL = _compute_mpl(graph.max_distance, ml_Sap)
-    print(f"The maximum possible flow for SAP (graph {graph_no}) is {max_flow_SAP}")
-    print(f"total augmenting paths for SAP for graph {graph_no} is {TAP_SAP}")
-    print(f"Mean Length for SAP for graph {graph_no} is {ml_Sap}")
-    print(f"MPL for graph {graph_no} is {MPL}")
-    print(f"Total edges of graph {graph_no} is {graph.total_edges}")
-
-    max_flow_DFS_like, TAP_DFS_like, ml_DFS_like = ford_fulkerson_DFS_like(residual.clone())
-    MPL = _compute_mpl(graph.max_distance, ml_DFS_like)
-    print(f"\nThe source is {graph.source} and the sink is {graph.sink}")
-    print(f"The maximum possible flow for DFS (graph {graph_no}) is {max_flow_DFS_like}")
-    print(f"total augmenting paths for DFS-like for graph {graph_no} is {TAP_DFS_like}")
-    print(f"Mean Length for DFS-like graph {graph_no} is {ml_DFS_like}")
-    print(f"MPL for graph {graph_no} is {MPL}")
-    print(f"Total edges of graph {graph_no} is {graph.total_edges}")
-
-    max_flow_maxcap, TAP_maxCap, ml_maxCap = ford_fulkerson_max_capacity(residual.clone())
-    MPL = _compute_mpl(graph.max_distance, ml_maxCap)
-    print(f"\nThe source is {graph.source} and the sink is {graph.sink}")
-    print(f"The maximum possible flow for maxCap (graph {graph_no}) is {max_flow_maxcap}")
-    print(f"total augmenting paths for maxCap for graph {graph_no} is {TAP_maxCap}")
-    print(f"Mean Length for maxCap graph {graph_no} is {ml_maxCap}")
-    print(f"MPL for graph {graph_no} is {MPL}")
-    print(f"Total edges of graph {graph_no} is {graph.total_edges}")
-
-    max_flow_random, TAP_random, ml_random = ford_fulkerson_random(residual.clone())
-    MPL = _compute_mpl(graph.max_distance, ml_random)
-    print(f"\nThe source is {graph.source} and the sink is {graph.sink}")
-    print(f"The maximum possible flow for random (graph {graph_no}) is {max_flow_random}")
-    print(f"total augmenting paths for random for graph {graph_no} is {TAP_random}")
-    print(f"Mean Length for random graph {graph_no} is {ml_random}")
-    print(f"MPL for graph {graph_no} is {MPL}")
-    print(f"Total edges of graph {graph_no} is {graph.total_edges}")
-
-
-def _compute_mpl(max_distance: Optional[float], mean_length: float) -> float:
-    if max_distance in (None, 0):
-        return 0
-    if isinf(float(max_distance)):
-        return 0
-    return mean_length / float(max_distance)
-
-
 def main():
-    graph_exist = True
+    missing_files = False
     for graph_no in range(1, 9):
         for file_type in ["vertices", "edges", "capacities", "adjlist", "meta_info"]:
             file_path = f"sim_val_{graph_no}_{file_type}.csv"
             if not os.path.exists(file_path):
                 print("Some or all files missing, regenerating graph and storing the data")
                 print(f"file missing : {file_path}")
-                graph_exist = False
+                missing_files = True
                 break
 
-    if not graph_exist:
+    if missing_files:
         generate_graphs()
 
-    if graph_exist:
-        for graph_no in range(1, 9):
-            run_algorithms(graph_no)
+    for graph_no in range(1, 9):
+        run_strategies_for_graph(graph_no)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a runner utility that loads graph data once, clones residual networks per strategy, and reports metrics for analysis
- simplify the CLI entrypoint to delegate to the runner and ensure graphs are generated when missing
- expose the runner helpers at the package level for reuse

## Testing
- python -m compileall ford_fulkerson main.py

------
