### PR TITLE
Add seed support for reproducible graph generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ python main.py
 
 The script will reuse the CSV data in `graph_data/` when available. If any file is missing it regenerates the corresponding
 graphs, saves them through `ford_fulkerson.io`, and then executes every augmenting-path strategy via `ford_fulkerson.runner`.
-Dataset regeneration runs headlessly by default; pass `--visualize` to open Matplotlib windows for each new graph:
+Dataset regeneration runs headlessly by default; pass `--visualize` to open Matplotlib windows for each new graph. Use
+`--seed` to make the generated graphs reproducible (the provided seed is incremented for each simulation value so the eight
+graphs remain distinct):
 
 ```bash
-python main.py --visualize
+python main.py --visualize --seed 1234
 ```
 
 ## Testing
@@ -88,10 +90,12 @@ pytest
   - `ford_fulkerson_max_capacity`: Greedy augmentation that always chooses the remaining path with maximum bottleneck capacity.
   - `ford_fulkerson_random`: Randomised tie-breaking on augmenting paths.
 - **Graph Generation (`ford_fulkerson.graph_generation`)**
-  - `GenerateSinkSourceGraph(n, r, upperCap)`: Creates a random graph and returns it as a `GraphInstance`.
+  - `GenerateSinkSourceGraph(n, r, upperCap, seed=None)`: Creates a random graph using the optional RNG seed and returns it as a
+    `GraphInstance`.
   - `visualize_graph(...)`: Optional Matplotlib helper for inspecting generated graphs.
 - **Data Persistence (`ford_fulkerson.io`)**
-  - `save_graph_data(graph, graph_no)`: Serialises vertices, edges, capacities, adjacency lists, and metadata to CSV.
+  - `save_graph_data(graph, graph_no)`: Serialises vertices, edges, capacities, adjacency lists, and metadata (including the
+    seed when present) to CSV.
   - `read_data(...)`: Loads the CSV bundle for a graph ID and reconstructs a `GraphInstance`.
 - **Simulation Runner (`ford_fulkerson.runner`)**
   - `run_strategies_for_graph(graph_no, strategies=None)`: Loads the stored graph once, clones the residual network per

--- a/ford_fulkerson/graph_generation.py
+++ b/ford_fulkerson/graph_generation.py
@@ -44,8 +44,13 @@ def visualize_graph(
     plt.show()
 
 
-def GenerateSinkSourceGraph(n: int, r: float, upperCap: float) -> GraphInstance:
+def GenerateSinkSourceGraph(
+    n: int, r: float, upperCap: float, seed: int | None = None
+) -> GraphInstance:
     """Generate a random directed graph with source and sink candidates."""
+
+    if seed is not None:
+        random.seed(seed)
 
     vertices: List[Vertex] = []
     edges: Set[Edge] = set()
@@ -88,6 +93,7 @@ def GenerateSinkSourceGraph(n: int, r: float, upperCap: float) -> GraphInstance:
         upper_cap=upperCap,
         max_distance=max_distance,
         total_edges=len(edges),
+        seed=seed,
     )
 
 

--- a/ford_fulkerson/io.py
+++ b/ford_fulkerson/io.py
@@ -34,6 +34,7 @@ def save_graph_data(graph: GraphInstance, graph_no: int) -> None:
                 "uppercap",
                 "longest_pathToSink",
                 "total_edges",
+                "seed",
             ]
         )
         writer.writerow(
@@ -47,6 +48,7 @@ def save_graph_data(graph: GraphInstance, graph_no: int) -> None:
                 graph.upper_cap,
                 meta_distance_value,
                 graph.total_edges,
+                "" if graph.seed is None else graph.seed,
             ]
         )
         print("meta info saved")
@@ -108,6 +110,15 @@ def read_data(
         except ValueError:
             total_edges = 0
 
+        seed_value: int | None = None
+        if len(row) > 9:
+            raw_seed = row[9]
+            if raw_seed not in ("", None):
+                try:
+                    seed_value = int(float(raw_seed))
+                except ValueError:
+                    seed_value = None
+
     vertices: List[Vertex] = []
     with open(file_path2, "r") as csvfile:
         reader = csv.reader(csvfile)
@@ -160,5 +171,6 @@ def read_data(
         upper_cap=upperCap,
         max_distance=maxdist,
         total_edges=total_edges or len(edges),
+        seed=seed_value,
     )
 

--- a/ford_fulkerson/models.py
+++ b/ford_fulkerson/models.py
@@ -24,6 +24,7 @@ class GraphInstance:
     upper_cap: float
     max_distance: float | None = None
     total_edges: int | None = None
+    seed: int | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "vertices", tuple(self.vertices))

--- a/ford_fulkerson/runner.py
+++ b/ford_fulkerson/runner.py
@@ -80,6 +80,8 @@ def run_strategies_for_graph(
     print(f"\nGraph {graph_no}: source {graph.source}, sink {graph.sink}")
     if graph.total_edges is not None:
         print(f"Total edges: {graph.total_edges}")
+    if graph.seed is not None:
+        print(f"Seed: {graph.seed}")
 
     results: Dict[str, StrategyMetrics] = {}
 

--- a/main.py
+++ b/main.py
@@ -20,11 +20,10 @@ SIMULATION_VALUES = [
 ]
 
 
-def generate_graphs(visualize: bool = False):
-    graph_no = 0
-    for n, r, upperCap in SIMULATION_VALUES:
-        graph_no += 1
-        graph = GenerateSinkSourceGraph(n, r, upperCap)
+def generate_graphs(visualize: bool = False, seed: int | None = None):
+    for graph_no, (n, r, upperCap) in enumerate(SIMULATION_VALUES, start=1):
+        graph_seed = seed + graph_no - 1 if seed is not None else None
+        graph = GenerateSinkSourceGraph(n, r, upperCap, seed=graph_seed)
 
         if visualize:
             visualize_graph(
@@ -46,6 +45,14 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Render generated graphs when datasets are regenerated.",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help=(
+            "Base random seed for reproducible graph generation. "
+            "Each simulation value increments the base by one."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -62,7 +69,7 @@ def main():
                 break
 
     if missing_files:
-        generate_graphs(visualize=args.visualize)
+        generate_graphs(visualize=args.visualize, seed=args.seed)
 
     for graph_no in range(1, 9):
         run_strategies_for_graph(graph_no)


### PR DESCRIPTION
## Summary
- add an optional `--seed` flag that threads deterministic seeds through graph generation
- persist the per-graph seed in `GraphInstance` and the saved metadata so runs can be reproduced later
- surface the seed in the runner output and documentation for easier traceability

## Testing
- pytest

------
